### PR TITLE
Status handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -132,7 +132,7 @@ for entries in range(len(bib_database.entries)):
     resp = access_API("https://api.semanticscholar.org/v1/paper/" + DOI)
 
     # If user wants to exit after server is not allowing download break whole download loop
-    if resp == None:
+    if resp is None:
         break
 
     # If something else went wrong.


### PR DESCRIPTION
Closes #10

The KeyboardInterrupt was chosen to give the user some feedback if the semantic scholar API denies access to its database. The command should have interrupted the execution of the program until the user would have pressed any key on the keyboard. 
But apparently I did some bad research as the command did not do what I wanted it to do. 

With the changes the user gets some more feedback and can choose to wait until the  semantic scholar API allows the database to be accessed agaian or to exit the download. 

